### PR TITLE
fix: auto-register flows with es6 export default syntax

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -1,107 +1,101 @@
-const _ = require('lodash');
-const Promise = require('bluebird');
-const fs = require('fs');
+const _ = require('lodash')
+const Promise = require('bluebird')
+const fs = require('fs')
 const path = require('path')
 
-Promise.promisifyAll(fs);
+Promise.promisifyAll(fs)
 
 /**
- * 
- * @param {object} data 
+ *
+ * @param {object} data
  */
 async function getAllFilesAndPathsForRegister(data) {
-  const savedFilePath = [];
+  const savedFilePath = []
   async function getFolder(folderPath) {
-    const files = await fs.readdirAsync(folderPath);
-    
+    const files = await fs.readdirAsync(folderPath)
+
     await Promise.each(files, async file => {
-      const fullFilePath = path.join(folderPath, file);
-      const stats = await fs.statAsync(fullFilePath);
-      
-      if(stats.isDirectory()) {
-        await getFolder(fullFilePath);
+      const fullFilePath = path.join(folderPath, file)
+      const stats = await fs.statAsync(fullFilePath)
+
+      if (stats.isDirectory()) {
+        await getFolder(fullFilePath)
       } else {
-        savedFilePath.push(fullFilePath);
+        savedFilePath.push(fullFilePath)
       }
-    });
+    })
   }
 
-  await getFolder(data.flowsPath);
+  await getFolder(data.flowsPath)
   return { ...data, savedFilePath }
 }
 
 function normalizeAllPaths(data) {
-  const relativePath = _.map(data.savedFilePath, p => path.relative(data.flowsPath, p));
-  const jsAndTsFiles = _.filter(relativePath, p => p.endsWith('.js') || p.endsWith('.ts'));
-  const unregisteredPaths = _.filter(jsAndTsFiles, p => !p.includes('/_'));
+  const relativePath = _.map(data.savedFilePath, p => path.relative(data.flowsPath, p))
+  const jsAndTsFiles = _.filter(relativePath, p => p.endsWith('.js') || p.endsWith('.ts'))
+  const unregisteredPaths = _.filter(jsAndTsFiles, p => !p.includes('/_'))
   const removedIndexAndSuffix = _.map(unregisteredPaths, p => {
-    const indexPos = p.indexOf('/index.js');
-    if(indexPos !== -1) {
-      return p.substring(0, indexPos);
+    const indexPos = p.indexOf('/index.js')
+    if (indexPos !== -1) {
+      return p.substring(0, indexPos)
     }
 
-    return p.substring(0, p.length -3);
-  });
+    return p.substring(0, p.length - 3)
+  })
 
   return { ...data, flowsPaths: removedIndexAndSuffix }
 }
 
 async function registerFlows(data, unsafe) {
   await Promise.each(data.flowsPaths, p => {
-    const flowPath = path.join(data.flowsPath, p);
-    const flow = require(flowPath);
-    unsafe.flows.register(p, flow);
-  });
+    const flowPath = path.join(data.flowsPath, p)
+    const flow = require(flowPath)
+    flow.default ? unsafe.flows.register(p, flow.default) : unsafe.flows.register(p, flow)
+  })
 
-  return data;
+  return data
 }
 
 /**
- * 
- * @param {Object} data 
- * @param {string} data.setupPath 
- * @param {boolean} data.isSaveSetupInGlobal 
+ *
+ * @param {Object} data
+ * @param {string} data.setupPath
+ * @param {boolean} data.isSaveSetupInGlobal
  */
 async function loadSetup(data) {
-  const setupDir = await fs.readdirAsync(data.setupPath);
-  
-  setupDir.forEach((filename) => {
-    require(data.setupPath + filename);
-  });
+  const setupDir = await fs.readdirAsync(data.setupPath)
 
-  return data;
+  setupDir.forEach(filename => {
+    require(data.setupPath + filename)
+  })
+
+  return data
 }
 
 /**
- * 
- * @param {Object} data 
+ *
+ * @param {Object} data
  * @param {boolean} data.isWsServer
  * @param {string} data.routesPath
- * @param {Object} unsafe 
- * @param {Flows}  unsafe.flows 
+ * @param {Object} unsafe
+ * @param {Flows}  unsafe.flows
  */
 function loadRoutes(data, unsafe) {
-  if(data.isWsServer) {
-    require('./ws-routes')(unsafe.flows.execute.bind(unsafe.flows), data);
+  if (data.isWsServer) {
+    require('./ws-routes')(unsafe.flows.execute.bind(unsafe.flows), data)
   }
 
-  if(data.isRest) {
-    require('./rest-routes')(unsafe.flows.execute.bind(unsafe.flows), data);
+  if (data.isRest) {
+    require('./rest-routes')(unsafe.flows.execute.bind(unsafe.flows), data)
   }
 
   try {
-    require(data.routesPath)(unsafe.flows.execute.bind(unsafe.flows));
+    require(data.routesPath)(unsafe.flows.execute.bind(unsafe.flows))
   } catch {
-    console.warn('no routes path found, skip...');
+    console.warn('no routes path found, skip...')
   }
 
-  return data;
+  return data
 }
 
-module.exports = [
-  getAllFilesAndPathsForRegister,
-  normalizeAllPaths,
-  registerFlows,
-  loadSetup,
-  loadRoutes
-];
+module.exports = [getAllFilesAndPathsForRegister, normalizeAllPaths, registerFlows, loadSetup, loadRoutes]

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,101 +1,107 @@
-const _ = require('lodash')
-const Promise = require('bluebird')
-const fs = require('fs')
+const _ = require('lodash');
+const Promise = require('bluebird');
+const fs = require('fs');
 const path = require('path')
 
-Promise.promisifyAll(fs)
+Promise.promisifyAll(fs);
 
 /**
- *
- * @param {object} data
+ * 
+ * @param {object} data 
  */
 async function getAllFilesAndPathsForRegister(data) {
-  const savedFilePath = []
+  const savedFilePath = [];
   async function getFolder(folderPath) {
-    const files = await fs.readdirAsync(folderPath)
-
+    const files = await fs.readdirAsync(folderPath);
+    
     await Promise.each(files, async file => {
-      const fullFilePath = path.join(folderPath, file)
-      const stats = await fs.statAsync(fullFilePath)
-
-      if (stats.isDirectory()) {
-        await getFolder(fullFilePath)
+      const fullFilePath = path.join(folderPath, file);
+      const stats = await fs.statAsync(fullFilePath);
+      
+      if(stats.isDirectory()) {
+        await getFolder(fullFilePath);
       } else {
-        savedFilePath.push(fullFilePath)
+        savedFilePath.push(fullFilePath);
       }
-    })
+    });
   }
 
-  await getFolder(data.flowsPath)
+  await getFolder(data.flowsPath);
   return { ...data, savedFilePath }
 }
 
 function normalizeAllPaths(data) {
-  const relativePath = _.map(data.savedFilePath, p => path.relative(data.flowsPath, p))
-  const jsAndTsFiles = _.filter(relativePath, p => p.endsWith('.js') || p.endsWith('.ts'))
-  const unregisteredPaths = _.filter(jsAndTsFiles, p => !p.includes('/_'))
+  const relativePath = _.map(data.savedFilePath, p => path.relative(data.flowsPath, p));
+  const jsAndTsFiles = _.filter(relativePath, p => p.endsWith('.js') || p.endsWith('.ts'));
+  const unregisteredPaths = _.filter(jsAndTsFiles, p => !p.includes('/_'));
   const removedIndexAndSuffix = _.map(unregisteredPaths, p => {
-    const indexPos = p.indexOf('/index.js')
-    if (indexPos !== -1) {
-      return p.substring(0, indexPos)
+    const indexPos = p.indexOf('/index.js');
+    if(indexPos !== -1) {
+      return p.substring(0, indexPos);
     }
 
-    return p.substring(0, p.length - 3)
-  })
+    return p.substring(0, p.length -3);
+  });
 
   return { ...data, flowsPaths: removedIndexAndSuffix }
 }
 
 async function registerFlows(data, unsafe) {
   await Promise.each(data.flowsPaths, p => {
-    const flowPath = path.join(data.flowsPath, p)
-    const flow = require(flowPath)
+    const flowPath = path.join(data.flowsPath, p);
+    const flow = require(flowPath);
     flow.default ? unsafe.flows.register(p, flow.default) : unsafe.flows.register(p, flow)
-  })
+  });
 
-  return data
+  return data;
 }
 
 /**
- *
- * @param {Object} data
- * @param {string} data.setupPath
- * @param {boolean} data.isSaveSetupInGlobal
+ * 
+ * @param {Object} data 
+ * @param {string} data.setupPath 
+ * @param {boolean} data.isSaveSetupInGlobal 
  */
 async function loadSetup(data) {
-  const setupDir = await fs.readdirAsync(data.setupPath)
+  const setupDir = await fs.readdirAsync(data.setupPath);
+  
+  setupDir.forEach((filename) => {
+    require(data.setupPath + filename);
+  });
 
-  setupDir.forEach(filename => {
-    require(data.setupPath + filename)
-  })
-
-  return data
+  return data;
 }
 
 /**
- *
- * @param {Object} data
+ * 
+ * @param {Object} data 
  * @param {boolean} data.isWsServer
  * @param {string} data.routesPath
- * @param {Object} unsafe
- * @param {Flows}  unsafe.flows
+ * @param {Object} unsafe 
+ * @param {Flows}  unsafe.flows 
  */
 function loadRoutes(data, unsafe) {
-  if (data.isWsServer) {
-    require('./ws-routes')(unsafe.flows.execute.bind(unsafe.flows), data)
+  if(data.isWsServer) {
+    require('./ws-routes')(unsafe.flows.execute.bind(unsafe.flows), data);
   }
 
-  if (data.isRest) {
-    require('./rest-routes')(unsafe.flows.execute.bind(unsafe.flows), data)
+  if(data.isRest) {
+    require('./rest-routes')(unsafe.flows.execute.bind(unsafe.flows), data);
   }
 
   try {
-    require(data.routesPath)(unsafe.flows.execute.bind(unsafe.flows))
+    require(data.routesPath)(unsafe.flows.execute.bind(unsafe.flows));
   } catch {
-    console.warn('no routes path found, skip...')
+    console.warn('no routes path found, skip...');
   }
 
-  return data
+  return data;
 }
 
-module.exports = [getAllFilesAndPathsForRegister, normalizeAllPaths, registerFlows, loadSetup, loadRoutes]
+module.exports = [
+  getAllFilesAndPathsForRegister,
+  normalizeAllPaths,
+  registerFlows,
+  loadSetup,
+  loadRoutes
+];

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -1,174 +1,156 @@
-const _ = require('lodash')
-const initFlow = require('../lib/init')
-const fs = require('fs')
+const _ = require('lodash');
+const initFlow = require('../lib/init');
+const fs = require('fs');
 
-const actions = _.mapKeys(initFlow, f => f.name)
+const actions = _.mapKeys(initFlow, f => f.name);
+
 
 jest.mock('fs', () => ({
   readdirAsync: jest.fn(),
   statAsync: jest.fn()
-}))
+}));
 
 describe('init', () => {
+
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
   test('getAllFilesAndPathsForRegister should get paths of files', async () => {
-    fs.readdirAsync.mockImplementation(() => ['file1.js', 'file2.js', 'file3.js'])
-    fs.statAsync.mockImplementation(() => ({ isDirectory: jest.fn(() => false) }))
+    fs.readdirAsync.mockImplementation(() => ['file1.js','file2.js','file3.js']);
+    fs.statAsync.mockImplementation(() => ({isDirectory: jest.fn(() => false)}));
 
-    const res = await actions.getAllFilesAndPathsForRegister({ flowsPath: '' })
-    expect(res).toMatchObject({ flowsPath: '', savedFilePath: ['file1.js', 'file2.js', 'file3.js'] })
-  })
+    const res = await actions.getAllFilesAndPathsForRegister({flowsPath: ''});
+    expect(res).toMatchObject({flowsPath: '', savedFilePath: ['file1.js','file2.js','file3.js']})
+  });
 
   test('getAllFilesAndPathsForRegister should recursively scan folder', async () => {
-    fs.readdirAsync.mockImplementation(path =>
-      path === 'folder' ? ['file4.js', 'file5.js'] : ['file1.js', 'folder', 'file3.js']
-    )
-    fs.statAsync.mockImplementation(path => ({ isDirectory: jest.fn(() => (path === 'folder' ? true : false)) }))
+    fs.readdirAsync.mockImplementation((path) => path === 'folder' ? ['file4.js','file5.js'] : ['file1.js','folder','file3.js']);
+    fs.statAsync.mockImplementation((path) => ({isDirectory: jest.fn(() => path === 'folder' ? true : false)}));
 
-    const res = await actions.getAllFilesAndPathsForRegister({ flowsPath: '' })
-
-    expect(res).toMatchObject({
-      flowsPath: '',
-      savedFilePath: ['file1.js', 'folder/file4.js', 'folder/file5.js', 'file3.js']
-    })
-  })
+    const res = await actions.getAllFilesAndPathsForRegister({flowsPath: ''});
+    
+    expect(res).toMatchObject({flowsPath: '', savedFilePath: [ 'file1.js', 'folder/file4.js', 'folder/file5.js', 'file3.js' ]})
+  });
 
   test('normalizeAllPaths should get relatives paths', async () => {
     const res = await actions.normalizeAllPaths({
       flowsPath: '/home/user/projects/flowPath',
       savedFilePath: ['/home/user/projects/flowPath/flows/file2.js', '/home/user/projects/flowPath/flows/file1.js']
-    })
+    });
 
     expect(res).toMatchObject({
       flowsPath: '/home/user/projects/flowPath',
       flowsPaths: ['flows/file2', 'flows/file1']
-    })
-  })
+    });
+  });
 
   test('normalizeAllPaths should ignore non js/ts files', async () => {
     const res = await actions.normalizeAllPaths({
       flowsPath: '/home/user/projects/flowPath',
-      savedFilePath: [
-        '/home/user/projects/flowPath/flows/file2.js',
-        '/home/user/projects/flowPath/flows/file1.ts',
-        '/home/user/projects/flowPath/flows/to_ignore'
-      ]
-    })
+      savedFilePath: ['/home/user/projects/flowPath/flows/file2.js', '/home/user/projects/flowPath/flows/file1.ts', '/home/user/projects/flowPath/flows/to_ignore']
+    });
 
     expect(res).toMatchObject({
       flowsPath: '/home/user/projects/flowPath',
       flowsPaths: ['flows/file2', 'flows/file1']
-    })
-  })
+    });
+  });
 
   test('normalizeAllPaths should ignore path that start with underscore', async () => {
     const res = await actions.normalizeAllPaths({
       flowsPath: '/home/user/projects/flowPath',
-      savedFilePath: [
-        '/home/user/projects/flowPath/flows/file2.js',
-        '/home/user/projects/flowPath/flows/file1.ts',
-        '/home/user/projects/flowPath/flows/_to_ignore/test.js'
-      ]
-    })
+      savedFilePath: ['/home/user/projects/flowPath/flows/file2.js', '/home/user/projects/flowPath/flows/file1.ts', '/home/user/projects/flowPath/flows/_to_ignore/test.js']
+    });
 
     expect(res).toMatchObject({
       flowsPath: '/home/user/projects/flowPath',
       flowsPaths: ['flows/file2', 'flows/file1']
-    })
-  })
+    });
+  });
 
   test('normalizeAllPaths should remove index.js files', async () => {
     const res = await actions.normalizeAllPaths({
       flowsPath: '/home/user/projects/flowPath',
-      savedFilePath: [
-        '/home/user/projects/flowPath/flows/flow2/index.js',
-        '/home/user/projects/flowPath/flows/file1.ts'
-      ]
-    })
+      savedFilePath: ['/home/user/projects/flowPath/flows/flow2/index.js', '/home/user/projects/flowPath/flows/file1.ts']
+    });
 
+    expect(res).toMatchObject({
+      flowsPath: '/home/user/projects/flowPath',
+      flowsPaths: ['flows/flow2', 'flows/file1']
+    });
+  });
+  
+  test('registerFlows with export default', async () => {
+    jest.mock('/home/user/projects/flowPath/flows/flow2', () => ({ default: ['second', 'flow'] }), { virtual: true })
+    jest.mock('/home/user/projects/flowPath/flows/file1', () => ['actions', 'for', 'flow', '1'], { virtual: true })
+    const setup = { flows: { register: jest.fn() } }
+    const res = await actions.registerFlows(
+      {
+        flowsPath: '/home/user/projects/flowPath',
+        flowsPaths: ['flows/flow2', 'flows/file1']
+      },
+      setup
+    )
+
+    expect(setup.flows.register).toBeCalledTimes(2)
+    expect(setup.flows.register).toBeCalledWith('flows/file1', ['actions', 'for', 'flow', '1'])
+    expect(setup.flows.register).toBeCalledWith('flows/flow2', ['second', 'flow'])
     expect(res).toMatchObject({
       flowsPath: '/home/user/projects/flowPath',
       flowsPaths: ['flows/flow2', 'flows/file1']
     })
   })
-  describe('registerFlows', () => {
-    test('register a flow with export default', async () => {
-      jest.mock('/home/user/projects/flowPath/flows/flow2', () => ({ default: ['second', 'flow'] }), { virtual: true })
-      jest.mock('/home/user/projects/flowPath/flows/file1', () => ['actions', 'for', 'flow', '1'], { virtual: true })
-      const setup = { flows: { register: jest.fn() } }
-      const res = await actions.registerFlows(
-        {
-          flowsPath: '/home/user/projects/flowPath',
-          flowsPaths: ['flows/flow2', 'flows/file1']
-        },
-        setup
-      )
 
-      expect(setup.flows.register).toBeCalledTimes(2)
-      expect(setup.flows.register).toBeCalledWith('flows/file1', ['actions', 'for', 'flow', '1'])
-      expect(setup.flows.register).toBeCalledWith('flows/flow2', ['second', 'flow'])
-      expect(res).toMatchObject({
-        flowsPath: '/home/user/projects/flowPath',
-        flowsPaths: ['flows/flow2', 'flows/file1']
-      })
-    })
+  test('registerFlows should loop through every flowsPaths and dynamically require the files', async () => {
+    jest.mock('/home/user/projects/flowPath/flows/flow2', () => ['second', 'flow'], { virtual: true });
+    jest.mock('/home/user/projects/flowPath/flows/file1', () => ['actions', 'for', 'flow', '1'], { virtual: true });
 
-    test('loop through every flowsPaths and dynamically require the files', async () => {
-      jest.mock('/home/user/projects/flowPath/flows/flow2', () => ['second', 'flow'], { virtual: true })
-      jest.mock('/home/user/projects/flowPath/flows/file1', () => ['actions', 'for', 'flow', '1'], { virtual: true })
+    const setup = {flows: {register: jest.fn()}};
+    const res = await actions.registerFlows({
+      flowsPath: '/home/user/projects/flowPath',
+      flowsPaths: ['flows/flow2', 'flows/file1']
+    }, setup);
 
-      const setup = { flows: { register: jest.fn() } }
-      const res = await actions.registerFlows(
-        {
-          flowsPath: '/home/user/projects/flowPath',
-          flowsPaths: ['flows/flow2', 'flows/file1']
-        },
-        setup
-      )
-
-      expect(setup.flows.register).toBeCalledTimes(2)
-      expect(setup.flows.register).toBeCalledWith('flows/file1', ['actions', 'for', 'flow', '1'])
-      expect(setup.flows.register).toBeCalledWith('flows/flow2', ['second', 'flow'])
-      expect(res).toMatchObject({
-        flowsPath: '/home/user/projects/flowPath',
-        flowsPaths: ['flows/flow2', 'flows/file1']
-      })
-    })
-  })
+    expect(setup.flows.register).toBeCalledTimes(2);
+    expect(setup.flows.register).toBeCalledWith('flows/file1', ['actions', 'for', 'flow', '1'])
+    expect(setup.flows.register).toBeCalledWith('flows/flow2', ['second', 'flow']);
+    expect(res).toMatchObject({
+      flowsPath: '/home/user/projects/flowPath',
+      flowsPaths: ['flows/flow2', 'flows/file1']
+    });
+  });
 
   test('loadSetup should load the setup folder', async () => {
-    fs.readdirAsync.mockImplementation(() => ['setup1.js', 'setup2.js'])
+    fs.readdirAsync.mockImplementation(() => ['setup1.js','setup2.js']);
 
-    jest.mock('setup/setup1.js', () => ({}), { virtual: true })
-    jest.mock('setup/setup2.js', () => ({}), { virtual: true })
-
-    await actions.loadSetup({ setupPath: 'setup/' })
-  })
+    jest.mock('setup/setup1.js', () => ({}), { virtual: true });
+    jest.mock('setup/setup2.js', () => ({}), { virtual: true });
+    
+    await actions.loadSetup({setupPath: 'setup/'});
+  });
 
   test('leadRoutes should be building the routes for the application', async () => {
-    jest.mock('routes', () => jest.fn(), { virtual: true })
+    jest.mock('routes', () => jest.fn(), { virtual: true });
 
-    const routes = require('routes')
-    const unsafe = { flows: { execute: jest.fn() } }
-    const data = { isWsServer: false, routesPath: 'routes' }
+    const routes = require('routes');
+    const unsafe = {flows:{execute: jest.fn()}};
+    const data = {isWsServer: false, routesPath: 'routes'};
 
-    await actions.loadRoutes(data, unsafe)
+    await actions.loadRoutes(data, unsafe);
 
-    expect(routes).toHaveBeenCalledTimes(1)
-  })
+    expect(routes).toHaveBeenCalledTimes(1);
+  });
 
   test('leadRoutes should be automatically load ws routes in flag is true', async () => {
-    jest.mock('routes', () => jest.fn(), { virtual: true })
-    jest.mock('../lib/ws-routes', () => jest.fn(), { virtual: true })
+    jest.mock('routes', () => jest.fn(), { virtual: true });
+    jest.mock('../lib/ws-routes', () => jest.fn(), { virtual: true });
 
-    const wsRoutes = require('../lib/ws-routes')
-    const routes = require('routes')
+    const wsRoutes = require('../lib/ws-routes');
+    const routes = require('routes');
 
-    await actions.loadRoutes({ isWsServer: true, routesPath: 'routes' }, { flows: { execute: jest.fn() } })
-    expect(wsRoutes).toHaveBeenCalledTimes(1)
-    expect(routes).toHaveBeenCalledTimes(1)
-  })
-})
+    await actions.loadRoutes({isWsServer: true, routesPath: 'routes'}, {flows:{execute: jest.fn()}});
+    expect(wsRoutes).toHaveBeenCalledTimes(1);
+    expect(routes).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -1,135 +1,174 @@
-const _ = require('lodash');
-const initFlow = require('../lib/init');
-const fs = require('fs');
+const _ = require('lodash')
+const initFlow = require('../lib/init')
+const fs = require('fs')
 
-const actions = _.mapKeys(initFlow, f => f.name);
-
+const actions = _.mapKeys(initFlow, f => f.name)
 
 jest.mock('fs', () => ({
   readdirAsync: jest.fn(),
   statAsync: jest.fn()
-}));
+}))
 
 describe('init', () => {
-
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
   test('getAllFilesAndPathsForRegister should get paths of files', async () => {
-    fs.readdirAsync.mockImplementation(() => ['file1.js','file2.js','file3.js']);
-    fs.statAsync.mockImplementation(() => ({isDirectory: jest.fn(() => false)}));
+    fs.readdirAsync.mockImplementation(() => ['file1.js', 'file2.js', 'file3.js'])
+    fs.statAsync.mockImplementation(() => ({ isDirectory: jest.fn(() => false) }))
 
-    const res = await actions.getAllFilesAndPathsForRegister({flowsPath: ''});
-    expect(res).toMatchObject({flowsPath: '', savedFilePath: ['file1.js','file2.js','file3.js']})
-  });
+    const res = await actions.getAllFilesAndPathsForRegister({ flowsPath: '' })
+    expect(res).toMatchObject({ flowsPath: '', savedFilePath: ['file1.js', 'file2.js', 'file3.js'] })
+  })
 
   test('getAllFilesAndPathsForRegister should recursively scan folder', async () => {
-    fs.readdirAsync.mockImplementation((path) => path === 'folder' ? ['file4.js','file5.js'] : ['file1.js','folder','file3.js']);
-    fs.statAsync.mockImplementation((path) => ({isDirectory: jest.fn(() => path === 'folder' ? true : false)}));
+    fs.readdirAsync.mockImplementation(path =>
+      path === 'folder' ? ['file4.js', 'file5.js'] : ['file1.js', 'folder', 'file3.js']
+    )
+    fs.statAsync.mockImplementation(path => ({ isDirectory: jest.fn(() => (path === 'folder' ? true : false)) }))
 
-    const res = await actions.getAllFilesAndPathsForRegister({flowsPath: ''});
-    
-    expect(res).toMatchObject({flowsPath: '', savedFilePath: [ 'file1.js', 'folder/file4.js', 'folder/file5.js', 'file3.js' ]})
-  });
+    const res = await actions.getAllFilesAndPathsForRegister({ flowsPath: '' })
+
+    expect(res).toMatchObject({
+      flowsPath: '',
+      savedFilePath: ['file1.js', 'folder/file4.js', 'folder/file5.js', 'file3.js']
+    })
+  })
 
   test('normalizeAllPaths should get relatives paths', async () => {
     const res = await actions.normalizeAllPaths({
       flowsPath: '/home/user/projects/flowPath',
       savedFilePath: ['/home/user/projects/flowPath/flows/file2.js', '/home/user/projects/flowPath/flows/file1.js']
-    });
+    })
 
     expect(res).toMatchObject({
       flowsPath: '/home/user/projects/flowPath',
       flowsPaths: ['flows/file2', 'flows/file1']
-    });
-  });
+    })
+  })
 
   test('normalizeAllPaths should ignore non js/ts files', async () => {
     const res = await actions.normalizeAllPaths({
       flowsPath: '/home/user/projects/flowPath',
-      savedFilePath: ['/home/user/projects/flowPath/flows/file2.js', '/home/user/projects/flowPath/flows/file1.ts', '/home/user/projects/flowPath/flows/to_ignore']
-    });
+      savedFilePath: [
+        '/home/user/projects/flowPath/flows/file2.js',
+        '/home/user/projects/flowPath/flows/file1.ts',
+        '/home/user/projects/flowPath/flows/to_ignore'
+      ]
+    })
 
     expect(res).toMatchObject({
       flowsPath: '/home/user/projects/flowPath',
       flowsPaths: ['flows/file2', 'flows/file1']
-    });
-  });
+    })
+  })
 
   test('normalizeAllPaths should ignore path that start with underscore', async () => {
     const res = await actions.normalizeAllPaths({
       flowsPath: '/home/user/projects/flowPath',
-      savedFilePath: ['/home/user/projects/flowPath/flows/file2.js', '/home/user/projects/flowPath/flows/file1.ts', '/home/user/projects/flowPath/flows/_to_ignore/test.js']
-    });
+      savedFilePath: [
+        '/home/user/projects/flowPath/flows/file2.js',
+        '/home/user/projects/flowPath/flows/file1.ts',
+        '/home/user/projects/flowPath/flows/_to_ignore/test.js'
+      ]
+    })
 
     expect(res).toMatchObject({
       flowsPath: '/home/user/projects/flowPath',
       flowsPaths: ['flows/file2', 'flows/file1']
-    });
-  });
+    })
+  })
 
   test('normalizeAllPaths should remove index.js files', async () => {
     const res = await actions.normalizeAllPaths({
       flowsPath: '/home/user/projects/flowPath',
-      savedFilePath: ['/home/user/projects/flowPath/flows/flow2/index.js', '/home/user/projects/flowPath/flows/file1.ts']
-    });
+      savedFilePath: [
+        '/home/user/projects/flowPath/flows/flow2/index.js',
+        '/home/user/projects/flowPath/flows/file1.ts'
+      ]
+    })
 
     expect(res).toMatchObject({
       flowsPath: '/home/user/projects/flowPath',
       flowsPaths: ['flows/flow2', 'flows/file1']
-    });
-  });
+    })
+  })
+  describe('registerFlows', () => {
+    test('register a flow with export default', async () => {
+      jest.mock('/home/user/projects/flowPath/flows/flow2', () => ({ default: ['second', 'flow'] }), { virtual: true })
+      jest.mock('/home/user/projects/flowPath/flows/file1', () => ['actions', 'for', 'flow', '1'], { virtual: true })
+      const setup = { flows: { register: jest.fn() } }
+      const res = await actions.registerFlows(
+        {
+          flowsPath: '/home/user/projects/flowPath',
+          flowsPaths: ['flows/flow2', 'flows/file1']
+        },
+        setup
+      )
 
-  test('registerFlows should loop through every flowsPaths and dynamically require the files', async () => {
-    jest.mock('/home/user/projects/flowPath/flows/flow2', () => ['second', 'flow'], { virtual: true });
-    jest.mock('/home/user/projects/flowPath/flows/file1', () => ['actions', 'for', 'flow', '1'], { virtual: true });
+      expect(setup.flows.register).toBeCalledTimes(2)
+      expect(setup.flows.register).toBeCalledWith('flows/file1', ['actions', 'for', 'flow', '1'])
+      expect(setup.flows.register).toBeCalledWith('flows/flow2', ['second', 'flow'])
+      expect(res).toMatchObject({
+        flowsPath: '/home/user/projects/flowPath',
+        flowsPaths: ['flows/flow2', 'flows/file1']
+      })
+    })
 
-    const setup = {flows: {register: jest.fn()}};
-    const res = await actions.registerFlows({
-      flowsPath: '/home/user/projects/flowPath',
-      flowsPaths: ['flows/flow2', 'flows/file1']
-    }, setup);
+    test('loop through every flowsPaths and dynamically require the files', async () => {
+      jest.mock('/home/user/projects/flowPath/flows/flow2', () => ['second', 'flow'], { virtual: true })
+      jest.mock('/home/user/projects/flowPath/flows/file1', () => ['actions', 'for', 'flow', '1'], { virtual: true })
 
-    expect(setup.flows.register).toBeCalledTimes(2);
-    expect(setup.flows.register).toBeCalledWith('flows/file1', ['actions', 'for', 'flow', '1'])
-    expect(setup.flows.register).toBeCalledWith('flows/flow2', ['second', 'flow']);
-    expect(res).toMatchObject({
-      flowsPath: '/home/user/projects/flowPath',
-      flowsPaths: ['flows/flow2', 'flows/file1']
-    });
-  });
+      const setup = { flows: { register: jest.fn() } }
+      const res = await actions.registerFlows(
+        {
+          flowsPath: '/home/user/projects/flowPath',
+          flowsPaths: ['flows/flow2', 'flows/file1']
+        },
+        setup
+      )
+
+      expect(setup.flows.register).toBeCalledTimes(2)
+      expect(setup.flows.register).toBeCalledWith('flows/file1', ['actions', 'for', 'flow', '1'])
+      expect(setup.flows.register).toBeCalledWith('flows/flow2', ['second', 'flow'])
+      expect(res).toMatchObject({
+        flowsPath: '/home/user/projects/flowPath',
+        flowsPaths: ['flows/flow2', 'flows/file1']
+      })
+    })
+  })
 
   test('loadSetup should load the setup folder', async () => {
-    fs.readdirAsync.mockImplementation(() => ['setup1.js','setup2.js']);
+    fs.readdirAsync.mockImplementation(() => ['setup1.js', 'setup2.js'])
 
-    jest.mock('setup/setup1.js', () => ({}), { virtual: true });
-    jest.mock('setup/setup2.js', () => ({}), { virtual: true });
-    
-    await actions.loadSetup({setupPath: 'setup/'});
-  });
+    jest.mock('setup/setup1.js', () => ({}), { virtual: true })
+    jest.mock('setup/setup2.js', () => ({}), { virtual: true })
+
+    await actions.loadSetup({ setupPath: 'setup/' })
+  })
 
   test('leadRoutes should be building the routes for the application', async () => {
-    jest.mock('routes', () => jest.fn(), { virtual: true });
+    jest.mock('routes', () => jest.fn(), { virtual: true })
 
-    const routes = require('routes');
-    const unsafe = {flows:{execute: jest.fn()}};
-    const data = {isWsServer: false, routesPath: 'routes'};
+    const routes = require('routes')
+    const unsafe = { flows: { execute: jest.fn() } }
+    const data = { isWsServer: false, routesPath: 'routes' }
 
-    await actions.loadRoutes(data, unsafe);
+    await actions.loadRoutes(data, unsafe)
 
-    expect(routes).toHaveBeenCalledTimes(1);
-  });
+    expect(routes).toHaveBeenCalledTimes(1)
+  })
 
   test('leadRoutes should be automatically load ws routes in flag is true', async () => {
-    jest.mock('routes', () => jest.fn(), { virtual: true });
-    jest.mock('../lib/ws-routes', () => jest.fn(), { virtual: true });
+    jest.mock('routes', () => jest.fn(), { virtual: true })
+    jest.mock('../lib/ws-routes', () => jest.fn(), { virtual: true })
 
-    const wsRoutes = require('../lib/ws-routes');
-    const routes = require('routes');
+    const wsRoutes = require('../lib/ws-routes')
+    const routes = require('routes')
 
-    await actions.loadRoutes({isWsServer: true, routesPath: 'routes'}, {flows:{execute: jest.fn()}});
-    expect(wsRoutes).toHaveBeenCalledTimes(1);
-    expect(routes).toHaveBeenCalledTimes(1);
-  });
-});
+    await actions.loadRoutes({ isWsServer: true, routesPath: 'routes' }, { flows: { execute: jest.fn() } })
+    expect(wsRoutes).toHaveBeenCalledTimes(1)
+    expect(routes).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Patch for auto-register flow that uses es6 `export default` syntax 